### PR TITLE
Fixing squid:S2131 - squid:S2184

### DIFF
--- a/api/src/main/java/org/cache2k/CacheConfig.java
+++ b/api/src/main/java/org/cache2k/CacheConfig.java
@@ -299,7 +299,7 @@ public class CacheConfig<K, V> implements Serializable {
     if (v == -1 || v == Integer.MAX_VALUE) {
       expiryMillis = -1;
     }
-    expiryMillis = v * 1000;
+    expiryMillis = v * 1000L;
   }
 
   public int getExpirySeconds() {

--- a/core/src/main/java/org/cache2k/impl/BaseCache.java
+++ b/core/src/main/java/org/cache2k/impl/BaseCache.java
@@ -481,7 +481,7 @@ public abstract class BaseCache<K, V>
       maxLinger = -1;
       return;
     }
-    maxLinger = s * 1000;
+    maxLinger = s * 1000L;
   }
 
   @Override
@@ -506,7 +506,7 @@ public abstract class BaseCache<K, V>
   public void init() {
     synchronized (lock) {
       if (name == null) {
-        name = "" + cacheCnt++;
+        name = String.valueOf(cacheCnt++);
       }
 
       initializeHeapCache();
@@ -1089,7 +1089,7 @@ public abstract class BaseCache<K, V>
           Field f = TimerTask.class.getDeclaredField("state");
           f.setAccessible(true);
           int _state = f.getInt(e.task);
-          _timerState = _state + "";
+          _timerState = String.valueOf(_state);
         } catch (Exception x) {
           _timerState = x.toString();
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2131 - “Primitives should not be boxed just for ""String"" conversion”.
squid:S2184 - “Math operands should be cast before assignment”
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S2184
Please let me know if you have any questions.
Ayman Abdelghany.