### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/core/src/main/java/org/cache2k/impl/util/Cache2kVersion.java
+++ b/core/src/main/java/org/cache2k/impl/util/Cache2kVersion.java
@@ -61,6 +61,9 @@ public class Cache2kVersion {
     }
   }
 
+  private Cache2kVersion() {
+  }
+
   public static String getBuildNumber() {
     return buildNumber;
   }

--- a/core/src/main/java/org/cache2k/impl/util/ThreadDump.java
+++ b/core/src/main/java/org/cache2k/impl/util/ThreadDump.java
@@ -33,6 +33,9 @@ import java.lang.management.ThreadMXBean;
  */
 public class ThreadDump {
 
+  private ThreadDump() {
+  }
+
   public static String generateThredDump() {
     final StringBuilder sb = new StringBuilder();
     final ThreadMXBean _threadMXBean = ManagementFactory.getThreadMXBean();

--- a/core/src/main/java/org/cache2k/impl/util/TunableFactory.java
+++ b/core/src/main/java/org/cache2k/impl/util/TunableFactory.java
@@ -56,6 +56,9 @@ public final class TunableFactory {
 
   private static Properties customProperties;
 
+  private TunableFactory() {
+  }
+
   /**
    * Reload the tunable configuration from the system properties
    * and the configuration file.

--- a/core/src/main/java/org/cache2k/impl/util/Util.java
+++ b/core/src/main/java/org/cache2k/impl/util/Util.java
@@ -30,7 +30,10 @@ import java.sql.Timestamp;
  * @author Jens Wilke; created: 2014-12-18
  */
 public class Util {
-  
+
+  private Util() {
+  }
+
   public static String formatMillis(long _millis) {
      return new Timestamp(_millis).toString();
   }

--- a/core/src/test/java/org/cache2k/core/test/StaticUtil.java
+++ b/core/src/test/java/org/cache2k/core/test/StaticUtil.java
@@ -31,6 +31,9 @@ import java.util.Set;
  */
 public class StaticUtil {
 
+  private StaticUtil() {
+  }
+
   public static <T> Set<T> asSet(T... keys) {
     return new HashSet<T>(Arrays.asList(keys));
   }

--- a/jcache/provider/src/main/java/org/cache2k/jcache/provider/Util.java
+++ b/jcache/provider/src/main/java/org/cache2k/jcache/provider/Util.java
@@ -27,6 +27,9 @@ package org.cache2k.jcache.provider;
  */
 public class Util {
 
+  private Util() {
+  }
+
   public static <T> T checkKey(T _value) {
     return requireNonNull(_value, "cache key");
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.