### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/core/src/main/java/org/cache2k/impl/Entry.java
+++ b/core/src/main/java/org/cache2k/impl/Entry.java
@@ -555,6 +555,20 @@ public class Entry<K, T>
     }
   }
 
+  @Override
+  public int hashCode() {
+    int result = (int) (this.hitCnt ^ this.hitCnt >>> 32);
+    result = 31 * result + (int) (this.fetchedTime ^ this.fetchedTime >>> 32);
+    result = 31 * result + (int) (this.nextRefreshTime ^ this.nextRefreshTime >>> 32);
+    result = 31 * result + (this.key != null ? this.key.hashCode() : 0);
+    result = 31 * result + (this.value != null ? this.value.hashCode() : 0);
+    result = 31 * result + this.hashCode;
+    result = 31 * result + (this.another != null ? this.another.hashCode() : 0);
+    result = 31 * result + (this.next != null ? this.next.hashCode() : 0);
+    result = 31 * result + (this.prev != null ? this.prev.hashCode() : 0);
+    return result;
+  }
+
   static class InitialValueInEntryNeverReturned extends Object { }
 
   static class StaleMarker {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “equals(Object obj)" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.