### PR TITLE
Null pointers should not be dereferenced

### DIFF
--- a/api/src/main/java/org/cache2k/CacheBuilder.java
+++ b/api/src/main/java/org/cache2k/CacheBuilder.java
@@ -85,9 +85,9 @@ public abstract class CacheBuilder<K, V>
     CacheBuilder<K,T> cb = null;
     try {
       cb = (CacheBuilder<K,T>) PROTOTYPE.clone();
+      cb.root = cb;
+      cb.config = c;
     } catch (CloneNotSupportedException ignored) {  }
-    cb.root = cb;
-    cb.config = c;
     return cb;
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - “Null pointers should not be dereferenced”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259
Please let me know if you have any questions.
Ayman Abdelghany.