### PR TITLE
Explicitly close file resources

### DIFF
--- a/cache2k-api/src/main/java/org/cache2k/spi/SingleProviderResolver.java
+++ b/cache2k-api/src/main/java/org/cache2k/spi/SingleProviderResolver.java
@@ -92,19 +92,30 @@ public class SingleProviderResolver {
   }
 
   private static String readFile(String _name) throws IOException {
-    InputStream in = SingleProviderResolver.class.getClassLoader().getResourceAsStream(_name);
-    if (in == null) {
-      return null;
-    }
-    LineNumberReader r = new LineNumberReader(new InputStreamReader(in));
-    String l = r.readLine();
-    while (l != null) {
-      if (!l.startsWith("#")) {
-        return l;
+    InputStream in = null;
+    try {
+      in = SingleProviderResolver.class.getClassLoader().getResourceAsStream(_name);
+      if (in == null) {
+        return null;
       }
-      l = r.readLine();
+      LineNumberReader r = new LineNumberReader(new InputStreamReader(in));
+      String l = r.readLine();
+      while (l != null) {
+        if (!l.startsWith("#")) {
+          return l;
+        }
+        l = r.readLine();
+      }
+      throw new IOException("No class file name in resource: " + _name);
+    } finally {
+      try {
+        if (in != null) {
+          in.close();
+        }
+      } catch (IOException e) {
+        // Do something!
+      }
     }
-    throw new IOException("No class file name in resource: " + _name);
   }
 
 }

--- a/cache2k-core/src/main/java/org/cache2k/core/util/Cache2kVersion.java
+++ b/cache2k-core/src/main/java/org/cache2k/core/util/Cache2kVersion.java
@@ -20,6 +20,7 @@ package org.cache2k.core.util;
  * #L%
  */
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
@@ -35,26 +36,37 @@ public class Cache2kVersion {
   private static long timestamp = 0;
 
   static {
-    InputStream in = Cache2kVersion.class.getResourceAsStream("/org.cache2k.impl.version.txt");
+    InputStream in = null;
     try {
-      if (in != null) {
-        Properties p = new Properties();
-        p.load(in);
-        String s = p.getProperty("buildNumber");
-        if (isDefined(s)) {
-          buildNumber = s;
+      in = Cache2kVersion.class.getResourceAsStream("/org.cache2k.impl.version.txt");
+      try {
+        if (in != null) {
+          Properties p = new Properties();
+          p.load(in);
+          String s = p.getProperty("buildNumber");
+          if (isDefined(s)) {
+            buildNumber = s;
+          }
+          s = p.getProperty("version");
+          if (isDefined(s)) {
+            version = s;
+          }
+          s = p.getProperty("timestamp");
+          if (isDefined(s)) {
+            timestamp = Long.parseLong(s);
+          }
         }
-        s = p.getProperty("version");
-        if (isDefined(s)) {
-          version = s;
-        }
-        s = p.getProperty("timestamp");
-        if (isDefined(s)) {
-          timestamp = Long.parseLong(s);
-        }
+      } catch (Exception e) {
+        Log.getLog(Cache2kVersion.class).warn("error parsing version properties", e);
       }
-    } catch (Exception e) {
-      Log.getLog(Cache2kVersion.class).warn("error parsing version properties", e);
+    } finally {
+      try {
+        if (in != null) {
+          in.close();
+        }
+      } catch (IOException e) {
+        Log.getLog(Cache2kVersion.class).warn("error closing version file input stream", e);
+      }
     }
   }
 


### PR DESCRIPTION
When using cache2k inside a spinoff of the Dalvik VM, Dalvik's CloseGuard gets hung up on file streams not being closed.

Here's an example stack trace:

> System 5 A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
System 5 java.lang.Throwable: Explicit termination method 'end' not called
    at dalvik.system.CloseGuard.open(CloseGuard.java:180)
    at java.util.zip.Inflater.<init>(Inflater.java:82)
    at java.util.jar.StrictJarFile.getZipInputStream(StrictJarFile.java:198)
    at java.util.jar.StrictJarFile.getInputStream(StrictJarFile.java:165)
    at libcore.io.ClassPathURLStreamHandler$ClassPathURLConnection.getInputStream(ClassPathURLStreamHandler.java:211)
    at java.net.URL.openStream(URL.java:470)
    at java.lang.ClassLoader.getResourceAsStream(ClassLoader.java:455)
    at java.lang.Class.getResourceAsStream(Class.java:1195)
    at org.cache2k.core.util.Cache2kVersion.<clinit>(Cache2kVersion.java:38)
    at org.cache2k.core.Cache2kCoreProviderImpl.<init>(Cache2kCoreProviderImpl.java:61)
    at java.lang.Class.newInstance(Native Method)
    at org.cache2k.spi.SingleProviderResolver.resolve(SingleProviderResolver.java:85)
    at org.cache2k.spi.SingleProviderResolver.resolveMandatory(SingleProviderResolver.java:58)
    at org.cache2k.CacheManager.<clinit>(CacheManager.java:47)
    at org.cache2k.Cache2kBuilder.config(Cache2kBuilder.java:154)
    at org.cache2k.Cache2kBuilder.refreshAhead(Cache2kBuilder.java:531)
    ......

I've added try...finally blocks around the InputStreams with calls to close().

Would appreciate input on what to do in SingleProviderResolver if we cannot close the stream, as the logger doesn't appear to be available.