### PR TITLE
Remove redundant object creation in example

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/sections/_types.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/sections/_types.adoc
@@ -34,7 +34,7 @@ can be used:
 [source,java]
 ----
     Cache<Long, String> cache =
-      new Cache2kBuilder.of(Long.class, String.class)
+      Cache2kBuilder.of(Long.class, String.class)
         .eternal(true)
         .build();
 ----


### PR DESCRIPTION
Static methods should be called from the class instance, rather than the objects'.