### PR TITLE
Fix cache2k cause tomcat cannot stop log4j thread

### DIFF
--- a/cache2k-core/src/main/java/org/cache2k/core/util/Log.java
+++ b/cache2k-core/src/main/java/org/cache2k/core/util/Log.java
@@ -78,11 +78,10 @@ public abstract class Log {
       return;
     }
     try {
-      final org.slf4j.ILoggerFactory lf = org.slf4j.LoggerFactory.getILoggerFactory();
       logFactory = new LogFactory() {
         @Override
         public Log getLog(String s) {
-          return new Slf4jLogger(lf.getLogger(s));
+          return new Slf4jLogger(org.slf4j.LoggerFactory.getLogger(s));
         }
       };
       log("New instance, using SLF4J logging");


### PR DESCRIPTION
```
02-Jul-2019 10:39:38.637 WARN [Thread-7] org.apache.catalina.loader.WebappClassLoaderBase.clearReferencesThreads The web application [ROOT] appears to have started a thread named [Log4j2-TF-10-AsyncLogger[DefaultAsyncContext@main]-2] but has failed to stop it. This is very likely to create a memory leak. Stack trace of thread:
 sun.misc.Unsafe.park(Native Method)
 java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
 java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2078)
 com.lmax.disruptor.TimeoutBlockingWaitStrategy.waitFor(TimeoutBlockingWaitStrategy.java:38)
 com.lmax.disruptor.ProcessingSequenceBarrier.waitFor(ProcessingSequenceBarrier.java:56)
 com.lmax.disruptor.BatchEventProcessor.processEvents(BatchEventProcessor.java:159)
 com.lmax.disruptor.BatchEventProcessor.run(BatchEventProcessor.java:125)
 java.lang.Thread.run(Thread.java:748)
```
I have verified this but didn't investigate why, normally we use `org.slf4j.LoggerFactory.getLogger()` not `org.slf4j.LoggerFactory.getILoggerFactory().getLogger()`.
may the same applies to commons logging, `org.apache.commons.logging.LogFactory.getFactory().getInstance()` should be `org.apache.commons.logging.LogFactory.getLog`