### PR TITLE
Background Refresh / Refresh Ahead Policy #34

### DIFF
--- a/cache2k-api/src/main/java/org/cache2k/expiry/RefreshAheadPolicy.java
+++ b/cache2k-api/src/main/java/org/cache2k/expiry/RefreshAheadPolicy.java
@@ -50,7 +50,7 @@ public interface RefreshAheadPolicy<K, V, T> extends DataAware<K, V> {
 
     @Override
     public int requiredHits(Context<Object> ctx) {
-      return 1;
+      return 0;
     }
 
   };


### PR DESCRIPTION
Auto refresh need RefreshAheadPolicy#requiredHits return 0, but default return 1(means no auto refresh)